### PR TITLE
Feature: Add option to specify prefix so that we get to maintain specific import groups matching that prefix

### DIFF
--- a/goimports/golangci.go
+++ b/goimports/golangci.go
@@ -8,11 +8,13 @@ import (
 	"golang.org/x/tools/imports"
 )
 
-func Run(filename string) ([]byte, error) {
+func Run(filename, localPrefix string) ([]byte, error) {
 	src, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
+
+	imports.LocalPrefix = localPrefix
 
 	res, err := imports.Process(filename, src, options)
 	if err != nil {


### PR DESCRIPTION
We'd like the ability to specify the --local option (provided by go imports) on golang-ci. Please let me know if these changes are okay. I understand that they are breaking, but I am ready to open a PR to make the necessary changes in golangci-lint