### PR TITLE
fix(goimports): search for diff.exe on Windows

### DIFF
--- a/goimports/goimports.go
+++ b/goimports/goimports.go
@@ -46,7 +46,9 @@ func diff(b1, b2 []byte, filename string) (data []byte, err error) {
 	defer os.Remove(f2)
 
 	cmd := "diff"
-	if runtime.GOOS == "plan9" {
+	if runtime.GOOS == "windows" {
+		cmd = "diff.exe"
+	} else if runtime.GOOS == "plan9" {
 		cmd = "/bin/ape/diff"
 	}
 


### PR DESCRIPTION
On Windows searching for `diff` returns PowerShell cmdlet, rather than diff binary even when it is installed.

Related to golangci/golangci-lint#3408.